### PR TITLE
Hotfix/prisma sdk issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^3.7.0",
-        "@prisma/sdk": "^3.6.0",
+        "@prisma/sdk": "3.6.0",
         "chalk": "^4.1.2",
         "clear": "^0.1.0",
         "commander": "^8.3.0",
@@ -977,12 +977,13 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-3.8.0.tgz",
-      "integrity": "sha512-odYAbzfGvVWpDxhk2Yb03DlcCg6zKgJjt5admcp4xtr7u0f76B2NppC4TSGxvdQUGzPI6G37afu2oZCb/uwGfg==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-3.7.0.tgz",
+      "integrity": "sha512-fUJMvBOX5C7JPc0e3CJD6Gbelbu4dMJB4ScYpiht8HMUnRShw20ULOipTopjNtl6ekHQJ4muI7pXlQxWS9nMbw==",
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/engines-version": "3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f"
+        "@prisma/engines-version": "3.7.0-31.8746e055198f517658c08a0c426c7eec87f5a85f"
       },
       "engines": {
         "node": ">=12.6"
@@ -997,23 +998,23 @@
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-3.8.0.tgz",
-      "integrity": "sha512-dSOnKP3hhn8lBK2RRCHl2pnoJeOfyJZQ+G+/4cuUk03ZCccTw28Uz9XjwXjY7FnLKuxaiAeVtYhahXsMEqocKQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-3.6.0.tgz",
+      "integrity": "sha512-THh5YjfDCpvbU5NOfeGx7mOQZl8EADOZ1z3C0sEDYmYUnpBjmCrnLNRSMjmD1d9kDo5GgwkrbK9pnwonHiH0JQ==",
       "dependencies": {
         "@types/debug": "4.1.7",
         "ms": "2.1.3"
       }
     },
     "node_modules/@prisma/engine-core": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engine-core/-/engine-core-3.8.0.tgz",
-      "integrity": "sha512-xfdR8kQaoHNJJs9ph+oqWxgtSZZ8P+iJPEfYUV8VpAFhYkOGBke4K4OOgrepJtaksYPzQMqENMRpmlWEVGDTjA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engine-core/-/engine-core-3.6.0.tgz",
+      "integrity": "sha512-FkxUhjFfOuH6eeRU+Ilw6aZNxPS/3p/92FMCKbotTU/atAF/QrleDYrked7E+bphEZ66bYqTgUOnCQBrlwcovg==",
       "dependencies": {
-        "@prisma/debug": "3.8.0",
-        "@prisma/engines": "3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f",
-        "@prisma/generator-helper": "3.8.0",
-        "@prisma/get-platform": "3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f",
+        "@prisma/debug": "3.6.0",
+        "@prisma/engines": "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727",
+        "@prisma/generator-helper": "3.6.0",
+        "@prisma/get-platform": "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727",
         "chalk": "4.1.2",
         "execa": "5.1.1",
         "get-stream": "6.0.1",
@@ -1024,91 +1025,99 @@
         "undici": "3.3.6"
       }
     },
+    "node_modules/@prisma/engine-core/node_modules/@prisma/engines": {
+      "version": "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727.tgz",
+      "integrity": "sha512-dRClHS7DsTVchDKzeG72OaEyeDskCv91pnZ72Fftn0mp4BkUvX2LvWup65hCNzwwQm5IDd6A88APldKDnMiEMA==",
+      "hasInstallScript": true
+    },
     "node_modules/@prisma/engines": {
       "version": "3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f",
       "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f.tgz",
       "integrity": "sha512-bHYubuItSN/DGYo36aDu7xJiJmK52JOSHs4MK+KbceAtwS20BCWadRgtpQ3iZ2EXfN/B1T0iCXlNraaNwnpU2w==",
+      "devOptional": true,
       "hasInstallScript": true
     },
     "node_modules/@prisma/engines-version": {
-      "version": "3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f.tgz",
-      "integrity": "sha512-G2JH6yWt6ixGKmsRmVgaQYahfwMopim0u/XLIZUo2o/mZ5jdu7+BL+2V5lZr7XiG1axhyrpvlyqE/c0OgYSl3g=="
+      "version": "3.7.0-31.8746e055198f517658c08a0c426c7eec87f5a85f",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-3.7.0-31.8746e055198f517658c08a0c426c7eec87f5a85f.tgz",
+      "integrity": "sha512-+qx2b+HK7BKF4VCa0LZ/t1QCXsu6SmvhUQyJkOD2aPpmOzket4fEnSKQZSB0i5tl7rwCDsvAiSeK8o7rf+yvwg=="
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f.tgz",
-      "integrity": "sha512-XtHkjn4gCluHBm6i2MgAggAggpxRJd9WiJlTdSaoqujOjyqeW3mkqE1YhnBv23rzcb97JXlWGANdLRERVVPnLA==",
+      "version": "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727.tgz",
+      "integrity": "sha512-aTtjXF3PNKe+UQXqOjamwqvMZtM7R4wMzUkwZq19zTbs8Bqe5IUOKjw6tdHMOpQD10TxS2/nlXIsWvwZeniyYg==",
       "dependencies": {
-        "@prisma/debug": "3.7.0",
-        "@prisma/get-platform": "3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f",
-        "chalk": "4.1.2",
-        "execa": "5.1.1",
-        "find-cache-dir": "3.3.2",
-        "hasha": "5.2.2",
-        "http-proxy-agent": "5.0.0",
-        "https-proxy-agent": "5.0.0",
-        "make-dir": "3.1.0",
-        "node-fetch": "2.6.6",
-        "p-filter": "2.1.0",
-        "p-map": "4.0.0",
-        "p-retry": "4.6.1",
-        "progress": "2.0.3",
-        "rimraf": "3.0.2",
-        "temp-dir": "2.0.0",
-        "tempy": "1.0.1"
+        "@prisma/debug": "3.5.0",
+        "@prisma/get-platform": "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727",
+        "chalk": "^4.0.0",
+        "execa": "^5.0.0",
+        "find-cache-dir": "^3.3.1",
+        "hasha": "^5.2.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.0.2",
+        "node-fetch": "^2.6.0",
+        "p-filter": "^2.1.0",
+        "p-map": "^4.0.0",
+        "p-retry": "^4.2.0",
+        "progress": "^2.0.3",
+        "rimraf": "^3.0.2",
+        "temp-dir": "^2.0.0",
+        "tempy": "^1.0.0"
       }
     },
     "node_modules/@prisma/fetch-engine/node_modules/@prisma/debug": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-3.7.0.tgz",
-      "integrity": "sha512-3FdQRGUt2zSe1D+RnCh2wmbCiMmhX+BKNRnC6Ic8KHayXMbEuRR4Ofgt0AZHRCdEQBwVFvM2Yep9zN3hNnWssw==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-3.5.0.tgz",
+      "integrity": "sha512-JWBmzqxtbq6rJfMyIIQVL/QSAIsiCOp20ArTl5zUHtSYH/MrNmuQ69YAn9RuUQBOTIAQaVTIMII2xpN5kB5RRg==",
       "dependencies": {
         "@types/debug": "4.1.7",
         "ms": "2.1.3"
       }
     },
     "node_modules/@prisma/generator-helper": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@prisma/generator-helper/-/generator-helper-3.8.0.tgz",
-      "integrity": "sha512-iBIW5jR/JvBIzV0cZOut2ZIlgZczddBXCc7zQFKu9SwUfH8E+keS298pG0d7mvuyvDAkdOEsBXEfPBP1M3KaYQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@prisma/generator-helper/-/generator-helper-3.6.0.tgz",
+      "integrity": "sha512-/mwQvnTbuiZjVmLtCBuOK+Tz2+HLYjqOCCvsEH0LMxHQBtzVSG4/LhVHMYxs/4du8TdgpnguMh4wtRWJ9Ow/DQ==",
       "dependencies": {
-        "@prisma/debug": "3.8.0",
+        "@prisma/debug": "3.6.0",
         "@types/cross-spawn": "6.0.2",
         "chalk": "4.1.2",
         "cross-spawn": "7.0.3"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f.tgz",
-      "integrity": "sha512-GwLtdWBJDa65su4nNA/CaKu5bifME239L042N2Gl5YXiVJFmRehW/XyS6ZP6DVlcZtZ+0LxxA7owQRgvxHcsyw==",
+      "version": "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727.tgz",
+      "integrity": "sha512-zvlddqvNU5rXnjTeT+0DOyMwH9E8NwV1a1F3tYN6lNWAjpWx26nGDGkIOO5Nid5mIjz+SDz5VM2NEZ+HXgDuMQ==",
       "dependencies": {
-        "@prisma/debug": "3.7.0"
+        "@prisma/debug": "3.5.0"
       }
     },
     "node_modules/@prisma/get-platform/node_modules/@prisma/debug": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-3.7.0.tgz",
-      "integrity": "sha512-3FdQRGUt2zSe1D+RnCh2wmbCiMmhX+BKNRnC6Ic8KHayXMbEuRR4Ofgt0AZHRCdEQBwVFvM2Yep9zN3hNnWssw==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-3.5.0.tgz",
+      "integrity": "sha512-JWBmzqxtbq6rJfMyIIQVL/QSAIsiCOp20ArTl5zUHtSYH/MrNmuQ69YAn9RuUQBOTIAQaVTIMII2xpN5kB5RRg==",
       "dependencies": {
         "@types/debug": "4.1.7",
         "ms": "2.1.3"
       }
     },
     "node_modules/@prisma/sdk": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@prisma/sdk/-/sdk-3.8.0.tgz",
-      "integrity": "sha512-+GqR2iGecDZld/g7rw4oULKQ8Zmisa++5vhEtId5WuuJW0lARzc6GrROcfKOB1rgF/Zgpxtym20Chser2LWiEw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@prisma/sdk/-/sdk-3.6.0.tgz",
+      "integrity": "sha512-1rPhx0mj9N6UjNxvB/5lhJgfCKREJIqoib4T+TY530YlfT/1mEtX1llVJwgyTUEhEW+qTLV5GZ4pkl+V9iNR9Q==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "3.8.0",
-        "@prisma/engine-core": "3.8.0",
-        "@prisma/engines": "3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f",
-        "@prisma/fetch-engine": "3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f",
-        "@prisma/generator-helper": "3.8.0",
-        "@prisma/get-platform": "3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f",
+        "@prisma/debug": "3.6.0",
+        "@prisma/engine-core": "3.6.0",
+        "@prisma/engines": "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727",
+        "@prisma/fetch-engine": "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727",
+        "@prisma/generator-helper": "3.6.0",
+        "@prisma/get-platform": "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727",
         "@timsuchanek/copy": "1.4.5",
-        "archiver": "5.3.0",
+        "archiver": "4.0.2",
         "arg": "5.0.1",
         "chalk": "4.1.2",
         "checkpoint-client": "1.1.20",
@@ -1118,14 +1127,14 @@
         "execa": "5.1.1",
         "find-up": "5.0.0",
         "global-dirs": "3.0.0",
-        "globby": "11.1.0",
+        "globby": "11.0.4",
         "has-yarn": "2.1.0",
         "is-ci": "3.0.1",
         "make-dir": "3.1.0",
         "node-fetch": "2.6.6",
         "p-map": "4.0.0",
         "read-pkg-up": "7.0.1",
-        "resolve": "1.21.0",
+        "resolve": "1.20.0",
         "rimraf": "3.0.2",
         "shell-quote": "1.7.3",
         "string-width": "4.2.3",
@@ -1137,6 +1146,24 @@
         "tempy": "1.0.1",
         "terminal-link": "2.1.1",
         "tmp": "0.2.1"
+      }
+    },
+    "node_modules/@prisma/sdk/node_modules/@prisma/engines": {
+      "version": "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727.tgz",
+      "integrity": "sha512-dRClHS7DsTVchDKzeG72OaEyeDskCv91pnZ72Fftn0mp4BkUvX2LvWup65hCNzwwQm5IDd6A88APldKDnMiEMA==",
+      "hasInstallScript": true
+    },
+    "node_modules/@prisma/sdk/node_modules/resolve": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "dependencies": {
+        "is-core-module": "^2.2.0",
+        "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/@sindresorhus/is": {
@@ -1588,20 +1615,20 @@
       }
     },
     "node_modules/archiver": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.0.tgz",
-      "integrity": "sha512-iUw+oDwK0fgNpvveEsdQ0Ase6IIKztBJU2U0E9MzszMfmVVUyv1QJhS2ITW9ZCqx8dktAxVAjWWkKehuZE8OPg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-4.0.2.tgz",
+      "integrity": "sha512-B9IZjlGwaxF33UN4oPbfBkyA4V1SxNLeIhR1qY8sRXSsbdUkEHrrOvwlYFPx+8uQeCe9M+FG6KgO+imDmQ79CQ==",
       "dependencies": {
         "archiver-utils": "^2.1.0",
         "async": "^3.2.0",
         "buffer-crc32": "^0.2.1",
+        "glob": "^7.1.6",
         "readable-stream": "^3.6.0",
-        "readdir-glob": "^1.0.0",
-        "tar-stream": "^2.2.0",
-        "zip-stream": "^4.1.0"
+        "tar-stream": "^2.1.2",
+        "zip-stream": "^3.0.1"
       },
       "engines": {
-        "node": ">= 10"
+        "node": ">= 8"
       }
     },
     "node_modules/archiver-utils": {
@@ -2260,17 +2287,39 @@
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
     },
     "node_modules/compress-commons": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.1.tgz",
-      "integrity": "sha512-QLdDLCKNV2dtoTorqgxngQCMA+gWXkM/Nwu7FpeBhk/RdkzimqC3jueb/FDmaZeXh+uby1jkBqE3xArsLBE5wQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-3.0.0.tgz",
+      "integrity": "sha512-FyDqr8TKX5/X0qo+aVfaZ+PVmNJHJeckFBlq8jZGSJOgnynhfifoyl24qaqdUdDIBe0EVTHByN6NAkqYvE/2Xg==",
       "dependencies": {
         "buffer-crc32": "^0.2.13",
-        "crc32-stream": "^4.0.2",
+        "crc32-stream": "^3.0.1",
         "normalize-path": "^3.0.0",
-        "readable-stream": "^3.6.0"
+        "readable-stream": "^2.3.7"
       },
       "engines": {
-        "node": ">= 10"
+        "node": ">= 8"
+      }
+    },
+    "node_modules/compress-commons/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/compress-commons/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/concat-map": {
@@ -2344,31 +2393,24 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
-    "node_modules/crc-32": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.0.tgz",
-      "integrity": "sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==",
+    "node_modules/crc": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
       "dependencies": {
-        "exit-on-epipe": "~1.0.1",
-        "printj": "~1.1.0"
-      },
-      "bin": {
-        "crc32": "bin/crc32.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
+        "buffer": "^5.1.0"
       }
     },
     "node_modules/crc32-stream": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.2.tgz",
-      "integrity": "sha512-DxFZ/Hk473b/muq1VJ///PMNLj0ZMnzye9thBpmjpJKCc5eMgB95aK8zCGrGfQ90cWo561Te6HK9D+j4KPdM6w==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-3.0.1.tgz",
+      "integrity": "sha512-mctvpXlbzsvK+6z8kJwSJ5crm7yBwrQMTybJzMw1O4lLGJqjlDCXY2Zw7KheiA6XBEcBmfLx1D88mjRGVJtY9w==",
       "dependencies": {
-        "crc-32": "^1.2.0",
+        "crc": "^3.4.4",
         "readable-stream": "^3.4.0"
       },
       "engines": {
-        "node": ">= 10"
+        "node": ">= 6.9.0"
       }
     },
     "node_modules/create-require": {
@@ -2821,14 +2863,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/exit-on-epipe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
-      "integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/expect": {
       "version": "27.4.6",
       "resolved": "https://registry.npmjs.org/expect/-/expect-27.4.6.tgz",
@@ -3099,15 +3133,15 @@
       }
     },
     "node_modules/globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
       "dependencies": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
+        "fast-glob": "^3.1.1",
+        "ignore": "^5.1.4",
+        "merge2": "^1.3.0",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -5363,17 +5397,6 @@
       "resolved": "https://registry.npmjs.org/prettysize/-/prettysize-2.0.0.tgz",
       "integrity": "sha512-VVtxR7sOh0VsG8o06Ttq5TrI1aiZKmC+ClSn4eBPaNf4SHr5lzbYW+kYGX3HocBL/MfpVrRfFZ9V3vCbLaiplg=="
     },
-    "node_modules/printj": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
-      "integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==",
-      "bin": {
-        "printj": "bin/printj.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/prisma": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-3.8.0.tgz",
@@ -5624,14 +5647,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/readdir-glob": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.1.tgz",
-      "integrity": "sha512-91/k1EzZwDx6HbERR+zucygRFfiPl2zkIYZtv3Jjr6Mn7SkKcVct8aVO+sSRiGMc6fLf72du3d92/uY63YPdEA==",
-      "dependencies": {
-        "minimatch": "^3.0.4"
       }
     },
     "node_modules/readdirp": {
@@ -6942,16 +6957,16 @@
       }
     },
     "node_modules/zip-stream": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.0.tgz",
-      "integrity": "sha512-zshzwQW7gG7hjpBlgeQP9RuyPGNxvJdzR8SUM3QhxCnLjWN2E7j3dOvpeDcQoETfHx0urRS7EtmVToql7YpU4A==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-3.0.1.tgz",
+      "integrity": "sha512-r+JdDipt93ttDjsOVPU5zaq5bAyY+3H19bDrThkvuVxC0xMQzU1PJcS6D+KrP3u96gH9XLomcHPb+2skoDjulQ==",
       "dependencies": {
         "archiver-utils": "^2.1.0",
-        "compress-commons": "^4.1.0",
+        "compress-commons": "^3.0.0",
         "readable-stream": "^3.6.0"
       },
       "engines": {
-        "node": ">= 10"
+        "node": ">= 8"
       }
     }
   },
@@ -7672,31 +7687,31 @@
       }
     },
     "@prisma/client": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-3.8.0.tgz",
-      "integrity": "sha512-odYAbzfGvVWpDxhk2Yb03DlcCg6zKgJjt5admcp4xtr7u0f76B2NppC4TSGxvdQUGzPI6G37afu2oZCb/uwGfg==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-3.7.0.tgz",
+      "integrity": "sha512-fUJMvBOX5C7JPc0e3CJD6Gbelbu4dMJB4ScYpiht8HMUnRShw20ULOipTopjNtl6ekHQJ4muI7pXlQxWS9nMbw==",
       "requires": {
-        "@prisma/engines-version": "3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f"
+        "@prisma/engines-version": "3.7.0-31.8746e055198f517658c08a0c426c7eec87f5a85f"
       }
     },
     "@prisma/debug": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-3.8.0.tgz",
-      "integrity": "sha512-dSOnKP3hhn8lBK2RRCHl2pnoJeOfyJZQ+G+/4cuUk03ZCccTw28Uz9XjwXjY7FnLKuxaiAeVtYhahXsMEqocKQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-3.6.0.tgz",
+      "integrity": "sha512-THh5YjfDCpvbU5NOfeGx7mOQZl8EADOZ1z3C0sEDYmYUnpBjmCrnLNRSMjmD1d9kDo5GgwkrbK9pnwonHiH0JQ==",
       "requires": {
         "@types/debug": "4.1.7",
         "ms": "2.1.3"
       }
     },
     "@prisma/engine-core": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engine-core/-/engine-core-3.8.0.tgz",
-      "integrity": "sha512-xfdR8kQaoHNJJs9ph+oqWxgtSZZ8P+iJPEfYUV8VpAFhYkOGBke4K4OOgrepJtaksYPzQMqENMRpmlWEVGDTjA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engine-core/-/engine-core-3.6.0.tgz",
+      "integrity": "sha512-FkxUhjFfOuH6eeRU+Ilw6aZNxPS/3p/92FMCKbotTU/atAF/QrleDYrked7E+bphEZ66bYqTgUOnCQBrlwcovg==",
       "requires": {
-        "@prisma/debug": "3.8.0",
-        "@prisma/engines": "3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f",
-        "@prisma/generator-helper": "3.8.0",
-        "@prisma/get-platform": "3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f",
+        "@prisma/debug": "3.6.0",
+        "@prisma/engines": "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727",
+        "@prisma/generator-helper": "3.6.0",
+        "@prisma/get-platform": "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727",
         "chalk": "4.1.2",
         "execa": "5.1.1",
         "get-stream": "6.0.1",
@@ -7705,46 +7720,54 @@
         "p-retry": "4.6.1",
         "terminal-link": "2.1.1",
         "undici": "3.3.6"
+      },
+      "dependencies": {
+        "@prisma/engines": {
+          "version": "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727",
+          "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727.tgz",
+          "integrity": "sha512-dRClHS7DsTVchDKzeG72OaEyeDskCv91pnZ72Fftn0mp4BkUvX2LvWup65hCNzwwQm5IDd6A88APldKDnMiEMA=="
+        }
       }
     },
     "@prisma/engines": {
       "version": "3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f",
       "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f.tgz",
-      "integrity": "sha512-bHYubuItSN/DGYo36aDu7xJiJmK52JOSHs4MK+KbceAtwS20BCWadRgtpQ3iZ2EXfN/B1T0iCXlNraaNwnpU2w=="
+      "integrity": "sha512-bHYubuItSN/DGYo36aDu7xJiJmK52JOSHs4MK+KbceAtwS20BCWadRgtpQ3iZ2EXfN/B1T0iCXlNraaNwnpU2w==",
+      "devOptional": true
     },
     "@prisma/engines-version": {
-      "version": "3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f.tgz",
-      "integrity": "sha512-G2JH6yWt6ixGKmsRmVgaQYahfwMopim0u/XLIZUo2o/mZ5jdu7+BL+2V5lZr7XiG1axhyrpvlyqE/c0OgYSl3g=="
+      "version": "3.7.0-31.8746e055198f517658c08a0c426c7eec87f5a85f",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-3.7.0-31.8746e055198f517658c08a0c426c7eec87f5a85f.tgz",
+      "integrity": "sha512-+qx2b+HK7BKF4VCa0LZ/t1QCXsu6SmvhUQyJkOD2aPpmOzket4fEnSKQZSB0i5tl7rwCDsvAiSeK8o7rf+yvwg=="
     },
     "@prisma/fetch-engine": {
-      "version": "3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f.tgz",
-      "integrity": "sha512-XtHkjn4gCluHBm6i2MgAggAggpxRJd9WiJlTdSaoqujOjyqeW3mkqE1YhnBv23rzcb97JXlWGANdLRERVVPnLA==",
+      "version": "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727.tgz",
+      "integrity": "sha512-aTtjXF3PNKe+UQXqOjamwqvMZtM7R4wMzUkwZq19zTbs8Bqe5IUOKjw6tdHMOpQD10TxS2/nlXIsWvwZeniyYg==",
       "requires": {
-        "@prisma/debug": "3.7.0",
-        "@prisma/get-platform": "3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f",
-        "chalk": "4.1.2",
-        "execa": "5.1.1",
-        "find-cache-dir": "3.3.2",
-        "hasha": "5.2.2",
-        "http-proxy-agent": "5.0.0",
-        "https-proxy-agent": "5.0.0",
-        "make-dir": "3.1.0",
-        "node-fetch": "2.6.6",
-        "p-filter": "2.1.0",
-        "p-map": "4.0.0",
-        "p-retry": "4.6.1",
-        "progress": "2.0.3",
-        "rimraf": "3.0.2",
-        "temp-dir": "2.0.0",
-        "tempy": "1.0.1"
+        "@prisma/debug": "3.5.0",
+        "@prisma/get-platform": "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727",
+        "chalk": "^4.0.0",
+        "execa": "^5.0.0",
+        "find-cache-dir": "^3.3.1",
+        "hasha": "^5.2.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.0.2",
+        "node-fetch": "^2.6.0",
+        "p-filter": "^2.1.0",
+        "p-map": "^4.0.0",
+        "p-retry": "^4.2.0",
+        "progress": "^2.0.3",
+        "rimraf": "^3.0.2",
+        "temp-dir": "^2.0.0",
+        "tempy": "^1.0.0"
       },
       "dependencies": {
         "@prisma/debug": {
-          "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-3.7.0.tgz",
-          "integrity": "sha512-3FdQRGUt2zSe1D+RnCh2wmbCiMmhX+BKNRnC6Ic8KHayXMbEuRR4Ofgt0AZHRCdEQBwVFvM2Yep9zN3hNnWssw==",
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-3.5.0.tgz",
+          "integrity": "sha512-JWBmzqxtbq6rJfMyIIQVL/QSAIsiCOp20ArTl5zUHtSYH/MrNmuQ69YAn9RuUQBOTIAQaVTIMII2xpN5kB5RRg==",
           "requires": {
             "@types/debug": "4.1.7",
             "ms": "2.1.3"
@@ -7753,28 +7776,28 @@
       }
     },
     "@prisma/generator-helper": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@prisma/generator-helper/-/generator-helper-3.8.0.tgz",
-      "integrity": "sha512-iBIW5jR/JvBIzV0cZOut2ZIlgZczddBXCc7zQFKu9SwUfH8E+keS298pG0d7mvuyvDAkdOEsBXEfPBP1M3KaYQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@prisma/generator-helper/-/generator-helper-3.6.0.tgz",
+      "integrity": "sha512-/mwQvnTbuiZjVmLtCBuOK+Tz2+HLYjqOCCvsEH0LMxHQBtzVSG4/LhVHMYxs/4du8TdgpnguMh4wtRWJ9Ow/DQ==",
       "requires": {
-        "@prisma/debug": "3.8.0",
+        "@prisma/debug": "3.6.0",
         "@types/cross-spawn": "6.0.2",
         "chalk": "4.1.2",
         "cross-spawn": "7.0.3"
       }
     },
     "@prisma/get-platform": {
-      "version": "3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f.tgz",
-      "integrity": "sha512-GwLtdWBJDa65su4nNA/CaKu5bifME239L042N2Gl5YXiVJFmRehW/XyS6ZP6DVlcZtZ+0LxxA7owQRgvxHcsyw==",
+      "version": "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727.tgz",
+      "integrity": "sha512-zvlddqvNU5rXnjTeT+0DOyMwH9E8NwV1a1F3tYN6lNWAjpWx26nGDGkIOO5Nid5mIjz+SDz5VM2NEZ+HXgDuMQ==",
       "requires": {
-        "@prisma/debug": "3.7.0"
+        "@prisma/debug": "3.5.0"
       },
       "dependencies": {
         "@prisma/debug": {
-          "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-3.7.0.tgz",
-          "integrity": "sha512-3FdQRGUt2zSe1D+RnCh2wmbCiMmhX+BKNRnC6Ic8KHayXMbEuRR4Ofgt0AZHRCdEQBwVFvM2Yep9zN3hNnWssw==",
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-3.5.0.tgz",
+          "integrity": "sha512-JWBmzqxtbq6rJfMyIIQVL/QSAIsiCOp20ArTl5zUHtSYH/MrNmuQ69YAn9RuUQBOTIAQaVTIMII2xpN5kB5RRg==",
           "requires": {
             "@types/debug": "4.1.7",
             "ms": "2.1.3"
@@ -7783,18 +7806,18 @@
       }
     },
     "@prisma/sdk": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@prisma/sdk/-/sdk-3.8.0.tgz",
-      "integrity": "sha512-+GqR2iGecDZld/g7rw4oULKQ8Zmisa++5vhEtId5WuuJW0lARzc6GrROcfKOB1rgF/Zgpxtym20Chser2LWiEw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@prisma/sdk/-/sdk-3.6.0.tgz",
+      "integrity": "sha512-1rPhx0mj9N6UjNxvB/5lhJgfCKREJIqoib4T+TY530YlfT/1mEtX1llVJwgyTUEhEW+qTLV5GZ4pkl+V9iNR9Q==",
       "requires": {
-        "@prisma/debug": "3.8.0",
-        "@prisma/engine-core": "3.8.0",
-        "@prisma/engines": "3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f",
-        "@prisma/fetch-engine": "3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f",
-        "@prisma/generator-helper": "3.8.0",
-        "@prisma/get-platform": "3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f",
+        "@prisma/debug": "3.6.0",
+        "@prisma/engine-core": "3.6.0",
+        "@prisma/engines": "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727",
+        "@prisma/fetch-engine": "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727",
+        "@prisma/generator-helper": "3.6.0",
+        "@prisma/get-platform": "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727",
         "@timsuchanek/copy": "1.4.5",
-        "archiver": "5.3.0",
+        "archiver": "4.0.2",
         "arg": "5.0.1",
         "chalk": "4.1.2",
         "checkpoint-client": "1.1.20",
@@ -7804,14 +7827,14 @@
         "execa": "5.1.1",
         "find-up": "5.0.0",
         "global-dirs": "3.0.0",
-        "globby": "11.1.0",
+        "globby": "11.0.4",
         "has-yarn": "2.1.0",
         "is-ci": "3.0.1",
         "make-dir": "3.1.0",
         "node-fetch": "2.6.6",
         "p-map": "4.0.0",
         "read-pkg-up": "7.0.1",
-        "resolve": "1.21.0",
+        "resolve": "1.20.0",
         "rimraf": "3.0.2",
         "shell-quote": "1.7.3",
         "string-width": "4.2.3",
@@ -7823,6 +7846,22 @@
         "tempy": "1.0.1",
         "terminal-link": "2.1.1",
         "tmp": "0.2.1"
+      },
+      "dependencies": {
+        "@prisma/engines": {
+          "version": "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727",
+          "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727.tgz",
+          "integrity": "sha512-dRClHS7DsTVchDKzeG72OaEyeDskCv91pnZ72Fftn0mp4BkUvX2LvWup65hCNzwwQm5IDd6A88APldKDnMiEMA=="
+        },
+        "resolve": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+          "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+          "requires": {
+            "is-core-module": "^2.2.0",
+            "path-parse": "^1.0.6"
+          }
+        }
       }
     },
     "@sindresorhus/is": {
@@ -8211,17 +8250,17 @@
       }
     },
     "archiver": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.0.tgz",
-      "integrity": "sha512-iUw+oDwK0fgNpvveEsdQ0Ase6IIKztBJU2U0E9MzszMfmVVUyv1QJhS2ITW9ZCqx8dktAxVAjWWkKehuZE8OPg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-4.0.2.tgz",
+      "integrity": "sha512-B9IZjlGwaxF33UN4oPbfBkyA4V1SxNLeIhR1qY8sRXSsbdUkEHrrOvwlYFPx+8uQeCe9M+FG6KgO+imDmQ79CQ==",
       "requires": {
         "archiver-utils": "^2.1.0",
         "async": "^3.2.0",
         "buffer-crc32": "^0.2.1",
+        "glob": "^7.1.6",
         "readable-stream": "^3.6.0",
-        "readdir-glob": "^1.0.0",
-        "tar-stream": "^2.2.0",
-        "zip-stream": "^4.1.0"
+        "tar-stream": "^2.1.2",
+        "zip-stream": "^3.0.1"
       }
     },
     "archiver-utils": {
@@ -8714,14 +8753,38 @@
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
     },
     "compress-commons": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.1.tgz",
-      "integrity": "sha512-QLdDLCKNV2dtoTorqgxngQCMA+gWXkM/Nwu7FpeBhk/RdkzimqC3jueb/FDmaZeXh+uby1jkBqE3xArsLBE5wQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-3.0.0.tgz",
+      "integrity": "sha512-FyDqr8TKX5/X0qo+aVfaZ+PVmNJHJeckFBlq8jZGSJOgnynhfifoyl24qaqdUdDIBe0EVTHByN6NAkqYvE/2Xg==",
       "requires": {
         "buffer-crc32": "^0.2.13",
-        "crc32-stream": "^4.0.2",
+        "crc32-stream": "^3.0.1",
         "normalize-path": "^3.0.0",
-        "readable-stream": "^3.6.0"
+        "readable-stream": "^2.3.7"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "concat-map": {
@@ -8785,21 +8848,20 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
-    "crc-32": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.0.tgz",
-      "integrity": "sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==",
+    "crc": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
       "requires": {
-        "exit-on-epipe": "~1.0.1",
-        "printj": "~1.1.0"
+        "buffer": "^5.1.0"
       }
     },
     "crc32-stream": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.2.tgz",
-      "integrity": "sha512-DxFZ/Hk473b/muq1VJ///PMNLj0ZMnzye9thBpmjpJKCc5eMgB95aK8zCGrGfQ90cWo561Te6HK9D+j4KPdM6w==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-3.0.1.tgz",
+      "integrity": "sha512-mctvpXlbzsvK+6z8kJwSJ5crm7yBwrQMTybJzMw1O4lLGJqjlDCXY2Zw7KheiA6XBEcBmfLx1D88mjRGVJtY9w==",
       "requires": {
-        "crc-32": "^1.2.0",
+        "crc": "^3.4.4",
         "readable-stream": "^3.4.0"
       }
     },
@@ -9136,11 +9198,6 @@
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
     },
-    "exit-on-epipe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
-      "integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw=="
-    },
     "expect": {
       "version": "27.4.6",
       "resolved": "https://registry.npmjs.org/expect/-/expect-27.4.6.tgz",
@@ -9341,15 +9398,15 @@
       "dev": true
     },
     "globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
       "requires": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
+        "fast-glob": "^3.1.1",
+        "ignore": "^5.1.4",
+        "merge2": "^1.3.0",
         "slash": "^3.0.0"
       }
     },
@@ -11070,11 +11127,6 @@
       "resolved": "https://registry.npmjs.org/prettysize/-/prettysize-2.0.0.tgz",
       "integrity": "sha512-VVtxR7sOh0VsG8o06Ttq5TrI1aiZKmC+ClSn4eBPaNf4SHr5lzbYW+kYGX3HocBL/MfpVrRfFZ9V3vCbLaiplg=="
     },
-    "printj": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
-      "integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ=="
-    },
     "prisma": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-3.8.0.tgz",
@@ -11255,14 +11307,6 @@
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
         "util-deprecate": "^1.0.1"
-      }
-    },
-    "readdir-glob": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.1.tgz",
-      "integrity": "sha512-91/k1EzZwDx6HbERR+zucygRFfiPl2zkIYZtv3Jjr6Mn7SkKcVct8aVO+sSRiGMc6fLf72du3d92/uY63YPdEA==",
-      "requires": {
-        "minimatch": "^3.0.4"
       }
     },
     "readdirp": {
@@ -12218,12 +12262,12 @@
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     },
     "zip-stream": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.0.tgz",
-      "integrity": "sha512-zshzwQW7gG7hjpBlgeQP9RuyPGNxvJdzR8SUM3QhxCnLjWN2E7j3dOvpeDcQoETfHx0urRS7EtmVToql7YpU4A==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-3.0.1.tgz",
+      "integrity": "sha512-r+JdDipt93ttDjsOVPU5zaq5bAyY+3H19bDrThkvuVxC0xMQzU1PJcS6D+KrP3u96gH9XLomcHPb+2skoDjulQ==",
       "requires": {
         "archiver-utils": "^2.1.0",
-        "compress-commons": "^4.1.0",
+        "compress-commons": "^3.0.0",
         "readable-stream": "^3.6.0"
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-aurora",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "CLI tool that orchestrates prisma files in a way that allows multiple .prisma files with cross-relations",
   "main": "./lib/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@prisma/client": "^3.7.0",
-    "@prisma/sdk": "^3.6.0",
+    "@prisma/sdk": "3.6.0",
     "chalk": "^4.1.2",
     "clear": "^0.1.0",
     "commander": "^8.3.0",


### PR DESCRIPTION
Sticks the version of @prisma/sdk to `v3.7.0` because of an issue in `v3.8.0`.

`v3.9.0` has a fix already that will be available once released.

https://github.com/prisma/prisma/issues/11126