### PR TITLE
Implementing #18 glob pattern, check files that `endsWith` '.prisma' extension

### DIFF
--- a/src/helpers/expandGlobPatterns.ts
+++ b/src/helpers/expandGlobPatterns.ts
@@ -1,0 +1,33 @@
+import { promisify } from 'util';
+import globMod from 'glob';
+import type { AuroraConfig } from '../models';
+import { CONFIG_FILE_NAME } from '../util/CONSTANTS';
+
+const glob = promisify(globMod);
+/**
+ * Check for glob patterns in `config.files`, evaluate them and expand them to actual files
+ *
+ * @param config The Configuration object to expand
+ * @returns AuroraConfig
+ * @throws Exception if it fails to traverse the filesystem
+ */
+export const expandGlobPatterns = async (config: AuroraConfig): Promise<AuroraConfig> => {
+  try {
+    let result: AuroraConfig = { files: [], output: config.output };
+
+    for (let f in config.files) {
+      const file = config.files[f];
+      result.files = result.files.concat(await _expandIfGlob(file));
+    }
+
+    return result;
+  } catch (e) {
+    console.error(
+      `Aurora could not parse GLOB patterns in ${CONFIG_FILE_NAME} 'file' section. Please make sure these files exists and the GLOB pattern is valid.`
+    );
+    throw e;
+  }
+};
+
+const _expandIfGlob = async (file: string): Promise<string[]> =>
+  globMod.hasMagic(file) ? await glob(file, { nonull: true }) : [file];

--- a/src/helpers/getAuroraConfigJson.ts
+++ b/src/helpers/getAuroraConfigJson.ts
@@ -51,7 +51,7 @@ const validateConfigurationObject = (config: AuroraConfig) => {
     throw new Error(ERRORS.EMPTY_CONFIG_FILES);
   }
 
-  if (config.files.filter((file) => !file.includes('.prisma')).length) {
+  if (config.files.filter((file) => !file.endsWith('.prisma')).length) {
     console.error(`Invalid File. Only provide paths to .prisma files.`);
     throw new Error(ERRORS.NON_PRISMA_FILE);
   }
@@ -61,7 +61,7 @@ const validateConfigurationObject = (config: AuroraConfig) => {
     throw new Error(ERRORS.NO_OUTPUT_CONFIGURED);
   }
 
-  if (!config.output.includes('.prisma')) {
+  if (!config.output.endsWith('.prisma')) {
     console.error(`The Output file should have the .prisma extension.`);
     throw new Error(ERRORS.NON_PRISMA_FILE);
   }

--- a/src/helpers/getAuroraConfigJson.ts
+++ b/src/helpers/getAuroraConfigJson.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import { promisify } from 'util';
 import type { AuroraConfig } from '../models';
 import { CONFIG_FILE_NAME, ERRORS } from '../util/CONSTANTS';
+import { expandGlobPatterns } from './expandGlobPatterns';
 
 const readFile = promisify(fs.readFile);
 
@@ -22,7 +23,7 @@ export async function getAuroraConfigJSON(): Promise<AuroraConfig> {
     // Ensure all of the fields were provided and are valid
     validateConfigurationObject(config);
 
-    return JSON.parse(jsonString);
+    return expandGlobPatterns(config);
   } catch (e) {
     console.error(
       `Aurora could not load ${CONFIG_FILE_NAME}. Please make sure this file exists and is valid.`

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -2,5 +2,6 @@ import { parseSchema } from './parseSchema';
 import { getAuroraConfigJSON } from './getAuroraConfigJson';
 import { combineModels } from './combineModels';
 import { writeSchema } from './writeSchema';
+import { expandGlobPatterns } from './expandGlobPatterns';
 
-export { parseSchema, getAuroraConfigJSON, combineModels, writeSchema };
+export { parseSchema, getAuroraConfigJSON, combineModels, writeSchema, expandGlobPatterns };

--- a/src/tests/aurora.test.ts
+++ b/src/tests/aurora.test.ts
@@ -517,7 +517,7 @@ describe('aurora()', () => {
           'glob-test/models/*.prisma',
           'glob-test/nonexistent/*.prisma'
         ])
-      ).rejects.toThrowError();
+      ).rejects.toThrowError('ENOENT: no such file or directory');
     });
   });
 });

--- a/src/tests/aurora.test.ts
+++ b/src/tests/aurora.test.ts
@@ -451,4 +451,73 @@ describe('aurora()', () => {
       expect(generatedSchema).toContain('TestValue');
     });
   });
+
+  describe('Glob Config', () => {
+    it('should render global Glob Files', async () => {
+      const generatedSchema = await getGeneratedSchema(['glob-test/**/*.prisma']);
+
+      expect(generatedSchema).toContain('generator client');
+      expect(generatedSchema).toContain('datasource db');
+      expect(generatedSchema).toContain('model Person');
+      expect(generatedSchema).toContain('model User');
+      expect(generatedSchema).toContain('enum Environment');
+      expect(generatedSchema).toContain('enum Test');
+    });
+
+    it('should render individual Glob Files', async () => {
+      const generatedSchema = await getGeneratedSchema([
+        'glob-test/providers/*.prisma',
+        'glob-test/enums/*.prisma',
+        'glob-test/models/*.prisma'
+      ]);
+
+      expect(generatedSchema).toContain('generator client');
+      expect(generatedSchema).toContain('datasource db');
+      expect(generatedSchema).toContain('model Person');
+      expect(generatedSchema).toContain('model User');
+      expect(generatedSchema).toContain('enum Environment');
+      expect(generatedSchema).toContain('enum Test');
+    });
+
+    it('should render mixed Glob Files', async () => {
+      const generatedSchema = await getGeneratedSchema([
+        'glob-test/providers/datasource.prisma',
+        'glob-test/models/*.prisma',
+        'glob-test/enums/environment.prisma'
+      ]);
+
+      expect(generatedSchema).not.toContain('generator client');
+      expect(generatedSchema).toContain('datasource db');
+      expect(generatedSchema).toContain('model Person');
+      expect(generatedSchema).toContain('model User');
+      expect(generatedSchema).toContain('enum Environment');
+      expect(generatedSchema).not.toContain('enum Test');
+    });
+
+    it('should throw imaginary Glob Files', async () => {
+      // let error = null;
+      // try {
+      //   await getGeneratedSchema([
+      //     'glob-test/providers/*.prisma',
+      //     'glob-test/enums/*.prisma',
+      //     'glob-test/models/*.prisma',
+      //     'glob-test/nonexistent/*.prisma'
+      //   ]);
+      // } catch (err: any) {
+      //   error = err;
+      //   // console.log(error.message);
+      // }
+      // expect(error).not.toBeNull();
+      // expect(error.message).toContain('ENOENT: no such file or directory');
+
+      await expect(
+        getGeneratedSchema([
+          'glob-test/providers/*.prisma',
+          'glob-test/enums/*.prisma',
+          'glob-test/models/*.prisma',
+          'glob-test/nonexistent/*.prisma'
+        ])
+      ).rejects.toThrowError();
+    });
+  });
 });

--- a/src/tests/helpers/mockConfigFetcher.ts
+++ b/src/tests/helpers/mockConfigFetcher.ts
@@ -1,11 +1,11 @@
 import * as helpers from '../../helpers';
 export default function mockConfigFetcher(paths: string[]) {
-  jest.spyOn(helpers, 'getAuroraConfigJSON').mockImplementation(async () => {
-    return {
+  jest.spyOn(helpers, 'getAuroraConfigJSON').mockImplementation(async () =>
+    helpers.expandGlobPatterns({
       files: paths.map((path) => `src/tests/schemas/${path}`),
       output: './generated.prisma'
-    };
-  });
+    })
+  );
 
   jest.spyOn(helpers, 'writeSchema').mockImplementation(async (output, schema) => {});
 }

--- a/src/tests/schemas/glob-test/enums/environment.prisma
+++ b/src/tests/schemas/glob-test/enums/environment.prisma
@@ -1,0 +1,5 @@
+enum Environment {
+  DEV
+  TEST
+  PRODUCTION
+}

--- a/src/tests/schemas/glob-test/enums/test.prisma
+++ b/src/tests/schemas/glob-test/enums/test.prisma
@@ -1,0 +1,3 @@
+enum Test {
+  TEST
+}

--- a/src/tests/schemas/glob-test/models/person.prisma
+++ b/src/tests/schemas/glob-test/models/person.prisma
@@ -1,0 +1,5 @@
+model Person {
+  id Int @id @default(autoincrement())
+
+  @@index([id])
+}

--- a/src/tests/schemas/glob-test/models/user.prisma
+++ b/src/tests/schemas/glob-test/models/user.prisma
@@ -1,0 +1,4 @@
+model User {
+  id        Int    @id @default(autoincrement())
+  firstName String @map("first_name")
+}

--- a/src/tests/schemas/glob-test/providers/datasource.prisma
+++ b/src/tests/schemas/glob-test/providers/datasource.prisma
@@ -1,0 +1,4 @@
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}

--- a/src/tests/schemas/glob-test/providers/generator.prisma
+++ b/src/tests/schemas/glob-test/providers/generator.prisma
@@ -1,0 +1,3 @@
+generator client {
+  provider = "prisma-client-js"
+}


### PR DESCRIPTION
Hi, first of all, thanks for this wonderful module.

This PR has 
- a new feature: #18 glob pattern implementation
- a fix: `validateConfigurationObject()` checks for extension instead of containing string.