### PR TITLE
Enhancement/fix default values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-aurora",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "CLI tool that orchestrates prisma files in a way that allows multiple .prisma files with cross-relations",
   "main": "./lib/index.js",
   "bin": {

--- a/src/helpers/renderer.ts
+++ b/src/helpers/renderer.ts
@@ -258,7 +258,7 @@ function renderModelAttribute(attribute: ModelAttribute): string {
   if (pieces.length > 1) {
     pieces = [pieces[0], '(', ...pieces.slice(1), ')'];
   }
-  
+
   return pieces.join('');
 }
 

--- a/src/helpers/renderer.ts
+++ b/src/helpers/renderer.ts
@@ -253,12 +253,12 @@ function renderModelAttribute(attribute: ModelAttribute): string {
     ]
       .filter((chunk) => chunk.length)
       .join(', ')
-  ].filter((chunk) => chunk.length > 1);
+  ].filter((chunk) => chunk.length >= 1);
 
   if (pieces.length > 1) {
     pieces = [pieces[0], '(', ...pieces.slice(1), ')'];
   }
-
+  
   return pieces.join('');
 }
 

--- a/src/tests/aurora.test.ts
+++ b/src/tests/aurora.test.ts
@@ -315,6 +315,13 @@ describe('aurora()', () => {
           ]);
           expect(generatedSchema).toContain('id String @id @default("test", map: "mapping")');
         });
+
+        it('should render @default values that have a string length under 1', async () => {
+          const generatedSchema = await getGeneratedSchema([
+            'feature-specific/model-fields/model-field-@default-0.prisma'
+          ]);
+          expect(generatedSchema).toContain('count Int @default(2)');
+        });
       });
 
       describe('@unique', () => {

--- a/src/tests/schemas/feature-specific/model-fields/model-field-@default-0.prisma
+++ b/src/tests/schemas/feature-specific/model-fields/model-field-@default-0.prisma
@@ -1,0 +1,13 @@
+datasource db {
+    provider = "sqlite"
+    url      = "file:./dev.db"
+}
+
+generator client {
+    provider = "prisma-client-js"
+}
+
+model User {
+    id    String @id @default("test")
+    count Int    @default(2)
+}


### PR DESCRIPTION
This enhancement fixes #32

Default values were being filtered out if their stringified length were less than 1. It should have been less than or equal to because of cases like `@default(2)`